### PR TITLE
Migrate docker compose config from main repo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,28 @@
+
+##
+# App
+#
+ONETIME_DEBUG="false"
+HOST="localhost:3000"
+SSL="true"
+SECRET="CHANGEME"
+REDIS_URL="redis://CHANGEME@redis:6379/0"
+COLONEL="CHANGEME@EXAMPLE.com"
+
+
+
+##
+# SMTP Testing (see bin/smtp_test.rb)
+#
+SMTP_HOST=
+SMTP_PORT=
+SMTP_USERNAME=
+SMTP_PASSWORD=
+FROM_EMAIL=
+TO_EMAIL=
+
+
+##
+# Redis
+#
+REDIS_PASSWORD="CHANGEME"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,69 @@
+##
+# Pre-Commit Configuration
+#
+# Initial setup:
+#
+#   0. Install the pre-commit framework (if it isn't already on your system):
+#
+#         $ pip install pre-commit
+#
+#   1. Install the git hook:
+#
+#         $ pre-commit install --allow-missing-config
+#
+#
+# Other commands:
+#
+#   Run it on all the files in this repo:
+#     $ pre-commit run --all-files
+#
+#   Updating plugin repositories:
+#     $ pre-commit autoupdate
+#
+#   Automatically enable pre-commit on repositories
+#     $ git config --global init.templateDir ~/.git-template
+#     $ pre-commit init-templatedir ~/.git-template
+#
+# See also:
+#   - https://pre-commit.com for more information
+#   - https://pre-commit.com/hooks.html for more hooks
+#
+
+default_install_hook_types:
+  - pre-commit
+  - prepare-commit-msg
+
+fail_fast: true
+
+repos:
+  - repo: meta
+    hooks:
+      - id: check-hooks-apply
+      - id: check-useless-excludes
+      - id: identity
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: detect-private-key
+      - id: mixed-line-ending
+      - id: check-added-large-files
+        args: ["--maxkb=2000"]
+      - id: no-commit-to-branch
+        args: ["--branch", "develop", "--branch", "rel/.*"]
+      - id: check-merge-conflict
+      - id: forbid-submodules
+
+  - repo: https://github.com/avilaton/add-msg-issue-prefix-hook
+    rev: v0.0.11
+    hooks:
+      - id: add-msg-issue-prefix
+        stages: [prepare-commit-msg]
+        name: Link commit to Github issue
+        args:
+          - "--default="
+          - "--pattern=[a-zA-Z0-9]{0,10}-?[0-9]{1,5}"
+          - "--template=[#{}]"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
-# docker-compose
-Future home of onetime secret Docker Compose configuration
+# Onetime Secret - Docker Compose Configuration (WIP)
+
+This is the docker-compose configuration for Onetime Secret. It uses the official Docker image for Onetime Secret.
+
+> [!WARNING]
+>
+> This repository is a work in progress. We're in the process of migrating the configuration from the main repo. Excuse any bumps along the way.
+
+
+## Usage
+
+1. Clone this repository
+2. ...

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,79 @@
+##
+# DOCKER COMPOSE CONFIG - ONETIME SECRET
+#
+# Usage:
+#
+#     $ docker-compose up -d redis
+#     $ docker-compose up --build onetime
+#
+#         - or simply -
+#
+#     $ docker-compose up
+#
+#
+# Initial setup:
+#
+# Before running any docker-compose commands, copy the example
+# configuration files into place on the host machine (the system
+# that's running the docker daemon):
+#
+#     $ cp --preserve --no-clobber ./etc/config.example ./etc/config
+#     $ cp --preserve --no-clobber .env.example .env
+#
+# Modify each file as needed. They're both mounted inside the
+# onetime-app container so any changes you make "locally" on
+# the host are reflected inside the container immediately
+# without having to re-build.
+#
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: onetime-app
+    depends_on:
+      - redis
+    env_file:
+      - .env
+    entrypoint: ["./bin/entrypoint.sh"]
+
+    # Makes it possible to interact with the container inside a shell.
+    stdin_open: true
+    tty: true
+
+    # The bin/entrypoint.sh script already launches the webapp by
+    # default but the command can be customized by including one
+    # here. When supplied as a list, each string will be properly
+    # escaped to avoid shell injection vulnerabilities.
+    #
+    #   e.g.
+    #
+    #     command: ["bundle", "exec", "thin", "-R", "config.ru", "start"]
+
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "60m"
+        max-file: "3"
+    ports:
+      - 3000:3000
+
+    # Mounts the current working directory (.) into /app inside
+    # the container, which is where the webapp lives. This is a
+    # convenient way to develop in place without having to rebuild
+    # the image each time you make a change.
+    volumes:
+      - .:/app
+
+  redis:
+    image: redis:bookworm@sha256:e422889e156ebea83856b6ff973bfe0c86bce867d80def228044eeecf925592b
+    container_name: onetime-redis
+    ports:
+      - 6379:6379
+    volumes:
+      - redis-data:/data
+      - ./etc/redis.conf:/usr/local/etc/redis/redis.conf
+
+volumes:
+  redis-data:


### PR DESCRIPTION
This pull request contains the docker compose configuration from the main repository. This change allows for easier management and deployment of the Onetime Secret application. It also opens the door to include more example configurations.

https://github.com/onetimesecret/onetimesecret/pull/429

Fixes #1